### PR TITLE
ci: drop compatibility constraints, enable automatic releases via GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
         run: |
           pip3 install Cython==0.29.32
           pip3 install -r requirements.txt pyinstaller
+          pip uninstall torch -y
+          pip install torch==2.3.1+cpu --index-url https://download.pytorch.org/whl/cpu
 
       - name: Build local Cython module
         run: |
@@ -62,8 +64,6 @@ jobs:
         run: |
           pip install Cython==0.29.32
           pip install -r requirements.txt pyinstaller
-          pip uninstall torch -y
-          pip install torch==2.3.1+cpu --index-url https://download.pytorch.org/whl/cpu
       
       - name: Build local Cython module
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,3 +138,43 @@ jobs:
         with:
           name: PJSK-macOS-ARM-Zip
           path: PJSK-MultiGUI-macOS.zip
+  release-assets:
+    name: Upload to GitHub Release
+    needs:
+      - build-linux
+      - build-windows
+      - build-macos-intel
+      - build-macos-arm
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: PJSK-Linux
+          path: out/linux
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: PJSK-Windows
+          path: out/windows
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: PJSK-macOS-Intel-Zip
+          path: out/macos-intel
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: PJSK-macOS-ARM-Zip
+          path: out/macos-arm
+
+      - name: Upload to GitHub Releases
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            out/linux/**
+            out/windows/**
+            out/macos-intel/**
+            out/macos-arm/**
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           python3 setup.py build_ext --inplace
 
       - name: Build with PyInstaller
-        run: pyinstaller --clean --strip PJSK-MultiGUI.spec
+        run: pyinstaller --clean PJSK-MultiGUI.spec
 
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt update
-          sudo apt install -y python3 python3-pip build-essential libgl1 libx11-dev
+          sudo apt install -y python3 python3-pip build-essential libgl1 libx11-dev libsndfile1
 
       - name: Install Python dependencies
         run: |
@@ -38,7 +38,8 @@ jobs:
           python3 setup.py build_ext --inplace
 
       - name: Build with PyInstaller
-        run: pyinstaller --clean PJSK-MultiGUI.spec
+        run: pyinstaller --clean PJSK-MultiGUI.spec  \
+            --add-binary "/usr/lib/x86_64-linux-gnu/libsndfile.so.1:."
 
       - name: Compress dist folder
         run: |
@@ -119,9 +120,7 @@ jobs:
 
   build-macos-arm:
     runs-on: macos-14
-    name: Build on macOS ARM (target 11.0)
-    env:
-      MACOSX_DEPLOYMENT_TARGET: '11.0'
+    name: Build on macOS ARM
     steps:
       - uses: actions/checkout@v4
 
@@ -132,6 +131,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          brew install libsndfile || true
           pip install Cython==0.29.32
           pip install -r requirements.txt pyinstaller
       
@@ -141,7 +141,8 @@ jobs:
           python setup.py build_ext --inplace
 
       - name: Build with PyInstaller
-        run: pyinstaller PJSK-MultiGUI.spec
+        run: pyinstaller PJSK-MultiGUI.spec \
+            --add-binary "/opt/homebrew/lib/libsndfile.dylib:."
       
       - name: Compress .app bundle
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-    paths:
-      - '**.py'
-      - '**.spec'
-      - '.github/workflows/build.yml'
-      - requirements.txt
   workflow_dispatch:
   release:
     types: [published]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,8 @@ jobs:
         run: |
           pip install Cython==0.29.32
           pip install -r requirements.txt pyinstaller
+          pip uninstall torch -y
+          pip install torch==2.3.1+cpu --index-url https://download.pytorch.org/whl/cpu
       
       - name: Build local Cython module
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   build-linux:
     runs-on: ubuntu-22.04
+
+    env:
+      CUDA_VISIBLE_DEVICES: ''
+    
     name: Build on Linux
     steps:
       - uses: actions/checkout@v4
@@ -33,11 +37,15 @@ jobs:
       - name: Build with PyInstaller
         run: pyinstaller --clean PJSK-MultiGUI.spec
 
+      - name: Compress dist folder
+        run: |
+          tar -cf - dist/ | xz -9 -e > PJSK-MultiGUI-Linux-${{ github.ref_name }}.tar.xz
+
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v4
         with:
-          name: PJSK-Linux
-          path: dist/
+          name: PJSK-MultiGUI-Linux-TarXz
+          path: PJSK-MultiGUI-Linux-${{ github.ref_name }}.tar.xz
 
   build-windows:
     runs-on: windows-2022
@@ -62,12 +70,15 @@ jobs:
 
       - name: Build with PyInstaller
         run: pyinstaller PJSK-MultiGUI.spec
+      
+      - name: Compress Windows dist to ZIP
+        run: powershell Compress-Archive -Path dist/* -DestinationPath PJSK-MultiGUI-Windows-${{ github.ref_name }}.zip
 
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v4
         with:
-          name: PJSK-Windows
-          path: dist/
+          name: PJSK-MultiGUI-Windows-Zip
+          path: PJSK-MultiGUI-Windows-${{ github.ref_name }}.zip
 
   build-macos-intel:
     runs-on: macos-13
@@ -95,13 +106,13 @@ jobs:
 
       - name: Compress .app bundle
         run: |
-          ditto -c -k --sequesterRsrc --keepParent dist/PJSK-MultiGUI.app PJSK-MultiGUI-macOS.zip
+          ditto -c -k --sequesterRsrc --keepParent dist/PJSK-MultiGUI.app PJSK-MultiGUI-macOS-Intel-${{ github.ref_name }}.zip
 
       - name: Upload compressed .app zip
         uses: actions/upload-artifact@v4
         with:
-          name: PJSK-macOS-Intel-Zip
-          path: PJSK-MultiGUI-macOS.zip
+          name: PJSK-MultiGUI-macOS-Intel-Zip
+          path: PJSK-MultiGUI-macOS-Intel-${{ github.ref_name }}.zip
 
   build-macos-arm:
     runs-on: macos-14
@@ -131,13 +142,13 @@ jobs:
       
       - name: Compress .app bundle
         run: |
-          ditto -c -k --sequesterRsrc --keepParent dist/PJSK-MultiGUI.app PJSK-MultiGUI-macOS.zip
+          ditto -c -k --sequesterRsrc --keepParent dist/PJSK-MultiGUI.app PJSK-MultiGUI-macOS-ARM-${{ github.ref_name }}.zip
 
       - name: Upload compressed .app zip
         uses: actions/upload-artifact@v4
         with:
-          name: PJSK-macOS-ARM-Zip
-          path: PJSK-MultiGUI-macOS.zip
+          name: PJSK-MultiGUI-macOS-ARM-Zip
+          path: PJSK-MultiGUI-macOS-ARM-${{ github.ref_name }}.zip
   release-assets:
     name: Upload to GitHub Release
     needs:
@@ -150,22 +161,22 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: PJSK-Linux
+          name: PJSK-MultiGUI-Linux-TarXz
           path: out/linux
 
       - uses: actions/download-artifact@v4
         with:
-          name: PJSK-Windows
+          name: PJSK-MultiGUI-Windows-Zip
           path: out/windows
 
       - uses: actions/download-artifact@v4
         with:
-          name: PJSK-macOS-Intel-Zip
+          name: PJSK-MultiGUI-macOS-Intel-Zip
           path: out/macos-intel
 
       - uses: actions/download-artifact@v4
         with:
-          name: PJSK-macOS-ARM-Zip
+          name: PJSK-MultiGUI-macOS-ARM-Zip
           path: out/macos-arm
 
       - name: Upload to GitHub Releases

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,8 @@ jobs:
         run: |
           pip3 install Cython==0.29.32
           pip3 install -r requirements.txt pyinstaller
-          pip uninstall torch -y
+          pip uninstall -y torch triton
+          pip uninstall -y $(pip freeze | grep 'nvidia-' | cut -d '=' -f 1)
           pip install torch==2.3.1+cpu --index-url https://download.pytorch.org/whl/cpu
 
       - name: Build local Cython module
@@ -41,7 +42,7 @@ jobs:
 
       - name: Compress dist folder
         run: |
-          tar -cf - dist/ | xz -9 -e > PJSK-MultiGUI-Linux-${{ github.ref_name }}.tar.xz
+          tar -cf - dist/ | zstd -7 > PJSK-MultiGUI-Linux-${{ github.ref_name }}.tar.xz
 
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,24 +11,27 @@ on:
 jobs:
   build-linux:
     runs-on: ubuntu-22.04
-    name: Build on Linux (Ubuntu 20.04 via Docker)
+    name: Build on Linux
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build in Ubuntu 20.04 container
+      - name: Install system dependencies
         run: |
-          docker run --rm -v "$PWD":/app -w /app ubuntu:20.04 /bin/bash -c "
-            apt update &&
-            apt install -y python3 python3-pip build-essential libgl1 libx11-dev &&
-            pip3 install Cython==0.29.32 &&
-            pip3 install -r requirements.txt pyinstaller &&
-            pip3 uninstall -y torch &&
-            pip3 install torch==1.12.1 &&
-            cd monotonic_align &&
-            python3 setup.py build_ext --inplace &&
-            cd .. &&
-            pyinstaller --clean --strip PJSK-MultiGUI.spec
-          "
+          sudo apt update
+          sudo apt install -y python3 python3-pip build-essential libgl1 libx11-dev
+
+      - name: Install Python dependencies
+        run: |
+          pip3 install Cython==0.29.32
+          pip3 install -r requirements.txt pyinstaller
+
+      - name: Build local Cython module
+        run: |
+          cd monotonic_align
+          python3 setup.py build_ext --inplace
+
+      - name: Build with PyInstaller
+        run: pyinstaller --clean --strip PJSK-MultiGUI.spec
 
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v4
@@ -68,9 +71,7 @@ jobs:
 
   build-macos-intel:
     runs-on: macos-13
-    name: Build on macOS Intel (target 11.0)
-    env:
-      MACOSX_DEPLOYMENT_TARGET: '11.0'
+    name: Build on macOS Intel (target 13.0)
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,16 @@ name: Build PJSK-MultiGUI
 
 on:
   push:
+    tags:
+      - 'v*'
     paths:
       - '**.py'
       - '**.spec'
+      - '.github/workflows/build.yml'
       - requirements.txt
   workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   build-linux:

--- a/PJSK-MultiGUI.spec
+++ b/PJSK-MultiGUI.spec
@@ -20,11 +20,6 @@ a = Analysis(
     hooksconfig={},
     runtime_hooks=[],
     excludes=[
-        'tkinter',
-        'unittest',
-        'pytest',
-        'email',
-        'pydoc',
         'matplotlib.tests',
         'numpy.random._examples',
     ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ numpy==1.23.2
 pyopenjtalk-prebuilt==0.2.0
 scipy==1.9.1
 SoundFile==0.10.3.post1
-torch==2.4.1+cpu
+torch
 Unidecode==1.3.4
 ./monotonic_align

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ numpy==1.23.2
 pyopenjtalk-prebuilt==0.2.0
 scipy==1.9.1
 SoundFile==0.10.3.post1
-torch
+torch==2.7.1+cpu
 Unidecode==1.3.4
 ./monotonic_align

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ numpy==1.23.2
 pyopenjtalk-prebuilt==0.2.0
 scipy==1.9.1
 SoundFile==0.10.3.post1
-torch==2.7.1+cpu
+torch==2.4.1+cpu
 Unidecode==1.3.4
 ./monotonic_align

--- a/text/cleaners.py
+++ b/text/cleaners.py
@@ -20,7 +20,7 @@ def resource_path(relative_path):
 
 dic_dir = resource_path("janome/sysdic")
 # Tokenizer for Japanese
-tokenizer = Tokenizer(dic_dir=dic_dir)
+tokenizer = Tokenizer()
 
 def japanese_tokenization_cleaners(text):
     '''Pipeline for tokenizing Japanese text.'''


### PR DESCRIPTION
## Description:

This pull request introduces the following CI/CD improvements:
- Dropped platform compatibility for older systems:
  - Removed Docker-based Linux build (was targeting Ubuntu 20.04)
  - Dropped macOS 10.15 compatibility
  - Minimum supported runtime environments now are: 
    - Linux: Ubuntu 22.04 or newer
    - macOS: macOS 13.7 or newer (Intel and Apple Silicon)
    - Windows: Windows 10 or newer
- Added automatic release support via GitHub Actions:
   - Builds are triggered when pushing version tags (e.g. v1.4.0)
   - All build artifacts are uploaded to GitHub Releases automatically
---
## Usage (How to trigger a release)

To publish a new version:
```bash
git tag v1.4.0
git push origin v1.4.0
```

This will:
1. Trigger a GitHub Actions workflow
2. Build the app for Windows, macOS (Intel & ARM), and Linux
3. Upload all binaries to the [Releases](https://github.com/Kanade-nya/gui-resource/releases) page.